### PR TITLE
Add news and links about the tournament: foil: 2026-03-25

### DIFF
--- a/News.md
+++ b/News.md
@@ -10,6 +10,11 @@ title: "Excelsior Fencing Club"
 
 # News archive
 
+[link](News/2026/03/18/)
+{% include_relative News/2026/03/18/content.md %}
+
+---
+
 [link](News/2026/02/09/)
 {% include_relative News/2026/02/09/content.md %}
 

--- a/News/2026/03/18/content.md
+++ b/News/2026/03/18/content.md
@@ -4,6 +4,6 @@ We're planning on having a Foil tournament on Wednesday, March 25th.
 
 Please arrive by 6:30.
 
-If you want to let us know in advance that you want to participate, drop a note in the #tournaments channel in Discord or send e-mail to info@excelsiorfencing.ca.
+If you want to let us know in advance that you want to participate, drop a note in the `#tournaments` channel in Discord or send e-mail to `info@excelsiorfencing.ca`.
 
 ###### Posted: 2026-03-18

--- a/News/2026/03/18/content.md
+++ b/News/2026/03/18/content.md
@@ -6,7 +6,7 @@ Please arrive by 6:30.
 
 If you want to let us know in advance that you want to participate:
 
-- drop a note in the `#tournaments` channel in Discord.
+- drop a note in the `#tournaments` channel in Discord.  
   or
 - send e-mail to `info@excelsiorfencing.ca`.
 

--- a/News/2026/03/18/content.md
+++ b/News/2026/03/18/content.md
@@ -4,6 +4,10 @@ We're planning on having a Foil tournament on Wednesday, March 25th.
 
 Please arrive by 6:30.
 
-If you want to let us know in advance that you want to participate, drop a note in the `#tournaments` channel in Discord or send e-mail to `info@excelsiorfencing.ca`.
+If you want to let us know in advance that you want to participate:
+
+- drop a note in the `#tournaments` channel in Discord.
+  or
+- send e-mail to `info@excelsiorfencing.ca`.
 
 ###### Posted: 2026-03-18

--- a/News/2026/03/18/content.md
+++ b/News/2026/03/18/content.md
@@ -1,0 +1,9 @@
+## 2026 March foil tournament
+
+We're planning on having a Foil tournament on Wednesday, March 25th.
+
+Please arrive by 6:30.
+
+If you want to let us know in advance that you want to participate, drop a note in the #tournaments channel in Discord or send e-mail to info@excelsiorfencing.ca.
+
+###### Posted: 2026-03-18

--- a/News/2026/03/18/index.md
+++ b/News/2026/03/18/index.md
@@ -1,0 +1,11 @@
+---
+image:
+  path: /images/Excelsior-logo.png
+  type: image/png
+  alt: Excelsior Fencing Club
+description: 2026 March foil tournament
+site_name: Excelsior Fencing Club
+title: 2026 March foil tournament
+---
+
+{% include_relative content.md %}

--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ title: "Excelsior Fencing Club"
 
 # Excelsior Fencing Club
 
-[link](News/2026/02/09/)
-{% include_relative News/2026/02/09/content.md %}
+[link](News/2026/03/18/)
+{% include_relative News/2026/03/18/content.md %}
 
 ---


### PR DESCRIPTION
- Direct link to the tournament info: https://excelsiorfencing.ca/News/2026/03/18/
- Main page: https://excelsiorfencing.ca/
- News page: https://excelsiorfencing.ca/News.html

> [!note]
> I've switched the website to this branch, so those links should work.

---

Post-merge tasks:

- [ ] In https://github.com/Excelsior-Fencing-Club/Excelsior-fencing-website/settings/pages, switch the branch to publish from `tournament.2026-03-25.foil` to `main`.
- [ ] Wait for https://github.com/Excelsior-Fencing-Club/Excelsior-fencing-website/actions to complete a publish to the `main` branch.
- [ ] Delete the `tournament.2026-03-25.foil` branch. There will be a button near the bottom of this page you can use.
