### PR TITLE
News: General information holiday month camp fees

### DIFF
--- a/News.md
+++ b/News.md
@@ -10,6 +10,11 @@ title: Excelsior Fencing Club News
 
 # News archive
 
+[link](News/2026/08/02/)
+{% include_relative News/2026/08/02/content.md %}
+
+---
+
 [link](News/2026/07/31/)
 {% include_relative News/2026/07/31/content.md %}
 

--- a/News/2026/08/02/content.md
+++ b/News/2026/08/02/content.md
@@ -1,0 +1,8 @@
+
+## General information updated - holiday month camp fees
+
+Our [General information](/General_information.html) page now includes the **holiday month camp** fee for July, August, and December: **$50/month** for regular members.
+
+Reduced programming applies during those months. See the [Calendar](/Calendar.html) for closures.
+
+###### Posted: 2026-08-02

--- a/News/2026/08/02/index.md
+++ b/News/2026/08/02/index.md
@@ -1,0 +1,11 @@
+---
+image:
+  path: /images/Excelsior-logo.png
+  type: image/png
+  alt: Excelsior Fencing Club
+description: General information page updated with holiday month camp fees
+site_name: Excelsior Fencing Club
+title: General information updated — holiday month camp fees
+---
+
+{% include_relative content.md %}

--- a/index.md
+++ b/index.md
@@ -10,6 +10,11 @@ title: "Excelsior Fencing Club"
 
 # Excelsior Fencing Club
 
+[link](News/2026/08/02/)
+{% include_relative News/2026/08/02/content.md %}
+
+---
+
 [link](News/2026/07/31/)
 {% include_relative News/2026/07/31/content.md %}
 


### PR DESCRIPTION
## Summary
- Add news post (2026-08-02) announcing that General information now lists the holiday month camp fee ($50/month for July, August, and December).
- Wire the post into the homepage and news archive.

## Test plan
- [ ] Merge and confirm the post appears at the top of https://excelsiorfencing.ca/
- [ ] Open https://excelsiorfencing.ca/News/2026/08/02/ and verify links to General information and Calendar work
- [ ] Confirm the post appears in the news archive

Made with [Cursor](https://cursor.com)